### PR TITLE
Fix LLDB 8 command arguments

### DIFF
--- a/pymem/debugger/lldb.py
+++ b/pymem/debugger/lldb.py
@@ -17,5 +17,6 @@ class LLDBDebugger(BaseDebugger):
             r"expr (void) PyGILState_Release($gil)",
         ]
         arguments = ["-p", str(self.target_pid), "--batch"]
-        arguments.extend(f"--one-line={command}" for command in lldb_commands)
+        for command in lldb_commands:
+            arguments.extend(['--one-line', command])
         return [self.bin_path] + arguments

--- a/tests/test_debugger.py
+++ b/tests/test_debugger.py
@@ -48,9 +48,12 @@ def test_LLDBDebugger_format_command():
         "-p",
         "1",
         "--batch",
-        "--one-line=expr void * $gil = (void *) PyGILState_Ensure()",
-        '--one-line=expr (void) PyRun_SimpleString("import base64;exec(base64.b64decode(\\\'f.write(\'{"status": "OK"}\')\\\').decode());")',
-        "--one-line=expr (void) PyGILState_Release($gil)",
+        "--one-line",
+        "expr void * $gil = (void *) PyGILState_Ensure()",
+        "--one-line",
+        'expr (void) PyRun_SimpleString("import base64;exec(base64.b64decode(\\\'f.write(\'{"status": "OK"}\')\\\').decode());")',
+        "--one-line",
+        "expr (void) PyGILState_Release($gil)",
     ]
 
 


### PR DESCRIPTION
It will resolve #1 .
Using `key value` format argument instead of `key=value` will work.